### PR TITLE
production環境のホスト名をherokuから取得できるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ config/initializers/secret_token.rb
 
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml
-config/initializers/mail.rb
 config/initializers/settings.rb
 
 # dotenv

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,0 +1,21 @@
+if Rails.env.production?
+  ActionMailer::Base.default_url_options = { host: "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" }
+  ActionMailer::Base.delivery_method = :smtp
+  ActionMailer::Base.raise_delivery_errors = true
+  ActionMailer::Base.smtp_settings = {
+    enable_starttls_auto: true,
+    address: 'smtp.gmail.com',
+    port: '587',
+    domain: 'smtp.gmail.com',
+    authentication: 'plain',
+    user_name: ENV['MAIL_SERVER_NAME'],
+    password: ENV['MAIL_SERVER_PASSWORD']
+  }
+elsif Rails.env.development?
+  host = 'localhost:3000'
+  ActionMailer::Base.default_url_options = { host: host, protocol: 'http' }
+  ActionMailer::Base.delivery_method = :letter_opener
+else
+  ActionMailer::Base.default_url_options = { host: host, protocol: 'http' }
+  ActionMailer::Base.delivery_method = :test
+end


### PR DESCRIPTION
### 目的
メールを送信するためにproduction環境のホスト名をherokuから取得する

### やったこと
herokuの環境変数からherokuのアプリ名を取得する