### PR TITLE
productionでlibが読み込まれないので読み込み方法を変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,6 @@ module Ulima
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    config.autoload_paths += %W(#{config.root}/lib/validator)
+    config.eager_load_paths += %W(#{config.root}/lib/validator)
   end
 end


### PR DESCRIPTION
### 目的
productionでlibが読み込まれないので読み込み方法を変更

### やったこと
`config.auto_load_paths += %W(#{config.root}/lib/validator)`
から
`config.eager_load_paths += %W(#{config.root}/lib/validator)`
に変更