### PR TITLE
登録画像がリサイズの時に潰れていたので、正方形にトリムングする

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -203,3 +203,6 @@ footer {
   width: 200px;
   height: 50px;
 }
+.trim img {
+  object-fit: cover;
+}

--- a/app/uploaders/picture_uploader.rb
+++ b/app/uploaders/picture_uploader.rb
@@ -7,6 +7,9 @@ class PictureUploader < CarrierWave::Uploader::Base
   version :standard do
     process resize_to_fill: [400, 400, :center]
   end
+  version :thumbnail do
+    process resize_to_fill: [400, 400, :center]
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -2,7 +2,9 @@
   <li class="<%= item %>">
     <div>
       <% unless item.pictures.last.nil? %>
-        <div><%=cl_image_tag item.pictures.last.picture.url, size: "200x200"%></div>
+        <div class='trim'>
+          <%=cl_image_tag item.pictures.last.picture.url, size: "200x200"%>
+        </div>
       <% else %>
         <%=image_tag 'no_image.jpg', size: "200x200"%>
       <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,9 @@
     <div class="col-md-6">
       <div class="item_image">
         <% unless @item.pictures.last.nil? %>
-          <div><%=image_tag @item.pictures.last.picture.url, size: "400x400"%></div>
+          <div class="trim">
+            <%=image_tag @item.pictures.last.picture.url, size: "400x400"%>
+          </div>
         <% else %>
           <%=image_tag 'no_image.jpg', size: "400x400"%>
         <% end %>


### PR DESCRIPTION
### 目的
登録した画像が縦長や横長の場合に潰れてしまうので、潰れないように画像の長い方をトリミングし正方形にする。

### やったこと
CSSでトリミング処理を追加